### PR TITLE
Added resolve or crash utility function

### DIFF
--- a/Sources/Swift_IoC_Container/IoC.swift
+++ b/Sources/Swift_IoC_Container/IoC.swift
@@ -67,6 +67,14 @@ public final class IoC {
         return resolveOrNil(T.self)
     }
     
+    public func resolveOrCrash<T>() -> T {
+        do {
+            return try resolve(T.self)
+        } catch {
+            fatalError("No registered instance found for interface: \(T.self)")
+        }
+    }
+    
     public func unregisterAll() {
         singletons.removeAll()
         lazySingletons.removeAll()


### PR DESCRIPTION
When the function is called for a type that is not registered the execution will stop and print what exact type could not be resolved. This is useful for shorter class constructors, e.g:

```
class MyClass {
    init(_ myService: MyServiceProtocol = IoC.resolveOrCrash()){}
}
```

The function is obviously untestable :)